### PR TITLE
assume a linear scale between min and max for position, velocity and current

### DIFF
--- a/src/Factors.cpp
+++ b/src/Factors.cpp
@@ -17,46 +17,34 @@ int32_t Factors::clamp1000(float value) {
 }
 
 
-static float toSI(int32_t roboteq, float max, int32_t zero, float min) {
-    if (roboteq > zero) {
-        return static_cast<float>(roboteq - zero) / (1000.0 - zero) * max;
-    }
-    else {
-        return static_cast<float>(zero - roboteq) / (1000.0 + zero) * min;
-    }
+static float toSI(int32_t roboteq, float max, float min) {
+    return (roboteq + 1000) * (max - min) / 2000 + min;
 }
 
-static int32_t fromSI(float si, float max, int32_t zero, float min) {
-    float v;
-    if (si > 0) {
-        v = (si / max) * (1000.0 - zero) + zero;
-    }
-    else {
-        v = (si / min) * (-1000.0 - zero) + zero;
-    }
-
+static int32_t fromSI(float si, float max, float min) {
+    float v = 2000 * (si - min) / (max - min) - 1000;
     return Factors::clamp1000(std::round(v));
 }
 
 float Factors::relativePositionToSI(int32_t position) const {
-    return toSI(position, position_max, position_zero, position_min);
+    return toSI(position, position_max, position_min);
 }
 
 int32_t Factors::relativePositionFromSI(float position) const {
-    return fromSI(position, position_max, position_zero, position_min);
+    return fromSI(position, position_max, position_min);
 }
 
 float Factors::relativeSpeedToSI(int32_t speed) const {
-    return toSI(speed, speed_max, speed_zero, speed_min);
+    return toSI(speed, speed_max, speed_min);
 }
 
 int32_t Factors::relativeSpeedFromSI(float speed) const {
-    return clamp1000(fromSI(speed, speed_max, speed_zero, speed_min));
+    return clamp1000(fromSI(speed, speed_max, speed_min));
 }
 
 int32_t Factors::relativeTorqueFromSI(float torque) const {
     float current = currentFromTorqueSI(torque);
-    return clamp1000(fromSI(current, max_current, 0, -max_current));
+    return clamp1000(fromSI(current, max_current, -max_current));
 }
 
 float Factors::rpmToSI(float speed) const {

--- a/test/test_DS402Channel.cpp
+++ b/test/test_DS402Channel.cpp
@@ -25,10 +25,8 @@ struct ChannelTestBase : public Helpers {
         , channel(driver.getChannel(CHANNEL_ID)) {
 
         Factors factors;
-        factors.speed_zero = -50;
         factors.speed_min = -1;
         factors.speed_max = 2.5;
-        factors.position_zero = 100;
         factors.position_min = -3;
         factors.position_max = 4;
         factors.torque_constant = 0.3;
@@ -379,7 +377,7 @@ TEST_P(ProfileRelativePositionModes, it_writes_the_target_position_and_desired_v
     int32_t rpm = can_open.get<int32_t>(0x6881, 0);
     int16_t acceleration = can_open.get<uint32_t>(0x6883, 0);
     int16_t deceleration = can_open.get<uint32_t>(0x6884, 0);
-    ASSERT_EQ(position, 168);
+    ASSERT_EQ(position, -57);
     ASSERT_EQ(rpm, 4);
     ASSERT_EQ(acceleration, 28);
     ASSERT_EQ(deceleration, 28);
@@ -405,7 +403,7 @@ TEST_P(ProfileRelativePositionModes, it_reports_joint_effort_pwm_and_position) {
     can_open.set<int16_t>(0x2100, 2, 12);
     can_open.set<int16_t>(0x2102, 2, 400);
     auto state = channel.getJointState();
-    ASSERT_NEAR(0.0888, state.position, 1e-4);
+    ASSERT_NEAR(0.92, state.position, 1e-4);
     ASSERT_FLOAT_EQ(1.2 / 0.3, state.effort);
     ASSERT_FLOAT_EQ(0.4, state.raw);
 }
@@ -489,7 +487,7 @@ TEST_P(DirectRelativePositionModes, it_creates_a_RPDO_mappings) {
 TEST_P(DirectRelativePositionModes, it_writes_the_target_position) {
     channel.setJointCommand(cmd);
     int32_t position = can_open.get<int32_t>(0x687a, 0);
-    ASSERT_EQ(position, 168);
+    ASSERT_EQ(position, -57);
 }
 
 TEST_P(DirectRelativePositionModes, it_throws_if_the_position_field_is_not_set) {
@@ -502,7 +500,7 @@ TEST_P(DirectRelativePositionModes, it_reports_joint_effort_pwm_and_position) {
     can_open.set<int16_t>(0x2100, 2, 12);
     can_open.set<int16_t>(0x2102, 2, 400);
     auto state = channel.getJointState();
-    ASSERT_NEAR(0.088888, state.position, 1e-4);
+    ASSERT_NEAR(0.92, state.position, 1e-4);
     ASSERT_FLOAT_EQ(1.2 / 0.3, state.effort);
     ASSERT_FLOAT_EQ(0.4, state.raw);
 }

--- a/test/test_Factors.cpp
+++ b/test/test_Factors.cpp
@@ -6,17 +6,15 @@ using namespace motors_roboteq_canopen;
 struct FactorsTest : public ::testing::Test {
     Factors factors;
     FactorsTest() {
-        factors.speed_zero = 100;
         factors.speed_min = -10;
         factors.speed_max = 42;
-        factors.position_zero = 250;
         factors.position_min = -100;
         factors.position_max = 84;
     }
 };
 
-TEST_F(FactorsTest, it_returns_SI_zero_at_speed_zero) {
-    ASSERT_FLOAT_EQ(0, factors.relativeSpeedToSI(100));
+TEST_F(FactorsTest, it_returns_the_center_of_the_min_max_range_at_speed_0) {
+    ASSERT_FLOAT_EQ(16, factors.relativeSpeedToSI(0));
 }
 
 TEST_F(FactorsTest, it_returns_SI_speed_min_at_relative_speed_minus_1000) {
@@ -27,8 +25,8 @@ TEST_F(FactorsTest, it_returns_SI_speed_max_at_relative_speed_1000) {
     ASSERT_FLOAT_EQ(42, factors.relativeSpeedToSI(1000));
 }
 
-TEST_F(FactorsTest, it_returns_speed_zero_at_SI_zero) {
-    ASSERT_FLOAT_EQ(100, factors.relativeSpeedFromSI(0));
+TEST_F(FactorsTest, it_returns_zero_at_the_center_of_the_min_max_range) {
+    ASSERT_FLOAT_EQ(0, factors.relativeSpeedFromSI(16));
 }
 
 TEST_F(FactorsTest, it_returns_speed_minus_1000_at_SI_speed_min) {
@@ -46,8 +44,8 @@ TEST_F(FactorsTest, it_clamps_the_relative_speed_at_plus_1000) {
     ASSERT_FLOAT_EQ(1000, factors.relativeSpeedFromSI(50));
 }
 
-TEST_F(FactorsTest, it_returns_SI_zero_at_position_zero) {
-    ASSERT_FLOAT_EQ(0, factors.relativePositionToSI(250));
+TEST_F(FactorsTest, it_returns_the_SI_center_of_the_min_max_range_at_position_zero) {
+    ASSERT_FLOAT_EQ(-8, factors.relativePositionToSI(0));
 }
 
 TEST_F(FactorsTest, it_returns_SI_position_min_at_relative_position_minus_1000) {
@@ -58,8 +56,8 @@ TEST_F(FactorsTest, it_returns_SI_position_max_at_relative_position_1000) {
     ASSERT_FLOAT_EQ(84, factors.relativePositionToSI(1000));
 }
 
-TEST_F(FactorsTest, it_returns_position_zero_at_SI_zero) {
-    ASSERT_FLOAT_EQ(250, factors.relativePositionFromSI(0));
+TEST_F(FactorsTest, it_returns_position_zero_at_the_SI_center_of_the_min_max_range) {
+    ASSERT_FLOAT_EQ(0, factors.relativePositionFromSI(-8));
 }
 
 TEST_F(FactorsTest, it_returns_position_minus_1000_at_SI_position_min) {


### PR DESCRIPTION
The current code was very badly trying to implement a piecewise linear approach,
where [min, 0] and [0, max] use different slopes.

To say the least, it was bad and buggy. Also, unused.

So, get rid of it for now. We can always reintroduce the functionality
in case it proves to be useful