### PR TITLE
add per-channel status flags to the controller status

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -52,6 +52,7 @@ vector<PDOMapping> Channel::getJointStateTPDOMapping() const {
     if (m_control_mode != CONTROL_OPEN_LOOP) {
         mapping.add<Feedback>(0, m_channel);
     }
+    mapping.add<ChannelStatusFlagsRaw>(0, m_channel);
     return vector<PDOMapping> { mapping };
 }
 

--- a/src/ControllerStatus.hpp
+++ b/src/ControllerStatus.hpp
@@ -1,6 +1,8 @@
 #ifndef MOTORS_ROBOTEQ_CANOPEN_CONTROLLERSTATUS_HPP
 #define MOTORS_ROBOTEQ_CANOPEN_CONTROLLERSTATUS_HPP
 
+#include <vector>
+
 #include <base/Float.hpp>
 #include <base/Temperature.hpp>
 
@@ -30,6 +32,17 @@ namespace motors_roboteq_canopen {
         FAULT_UNCONFIGURED = 0x80
     };
 
+    /** Bitfield values for Roboteq's channel state flags */
+    enum ChannelStatusFlags {
+        CHANNEL_STATUS_AMPS_LIMIT_ACTIVE = 1,
+        CHANNEL_STATUS_MOTOR_STALLED = 2,
+        CHANNEL_STATUS_LOOP_ERROR_DETECTED = 4,
+        CHANNEL_STATUS_SAFETY_STOP_ACTIVE = 8,
+        CHANNEL_STATUS_FORWARD_LIMIT_TRIGGERED = 16,
+        CHANNEL_STATUS_REVERSE_LIMIT_TRIGGERED = 32,
+        CHANNEL_STATUS_AMPS_TRIGGER_ACTIVATED = 64
+    };
+
     /** Single controller channel status
      */
     struct ControllerStatus {
@@ -46,6 +59,9 @@ namespace motors_roboteq_canopen {
         /** @meta bitfield /motors_roboteq_canopen/FaultFlags
          */
         uint16_t fault_flags = 0xFFFF;
+
+        /** @meta bitfields /motors_roboteq_canopen/ChannelStatusFlags */
+        std::vector<uint16_t> channel_status_flags;
     };
 }
 

--- a/src/DriverBase.cpp
+++ b/src/DriverBase.cpp
@@ -99,6 +99,7 @@ vector<canbus::Message> DriverBase::queryControllerStatus() {
     };
     for (size_t i = 0; i < m_channels.size(); ++i) {
         queries.push_back(queryUpload<TemperatureSensor0>(0, i));
+        queries.push_back(queryUpload<ChannelStatusFlagsRaw>(0, i));
     }
     return queries;
 }
@@ -116,6 +117,11 @@ ControllerStatus DriverBase::getControllerStatus() const {
     }
     status.status_flags = get<StatusFlagsRaw>();
     status.fault_flags = get<FaultFlagsRaw>();
+
+    status.channel_status_flags.resize(m_channels.size());
+    for (size_t i = 0; i < m_channels.size(); ++i) {
+        status.channel_status_flags[i] = get<ChannelStatusFlagsRaw>(0, i);
+    }
     return status;
 }
 

--- a/src/Objects.hpp
+++ b/src/Objects.hpp
@@ -26,6 +26,8 @@ namespace motors_roboteq_canopen {
 
     CANOPEN_DEFINE_OBJECT(0x2119, 0, Time,                          std::uint32_t);
 
+    CANOPEN_DEFINE_OBJECT(0x2122, 1, ChannelStatusFlagsRaw,         std::uint16_t);
+
     CANOPEN_DEFINE_OBJECT(0x2146, 0, AnalogInput,                   std::int16_t);
     CANOPEN_DEFINE_OBJECT(0x2147, 0, ConvertedAnalogInput,          std::int16_t);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 rock_gtest(test_suite suite.cpp Helpers.cpp
-    test_Factors.cpp test_DS402Channel.cpp test_DS402Driver.cpp
+    test_Factors.cpp
+    test_DS402Channel.cpp test_DS402Driver.cpp
+    test_Channel.cpp
     test_SerialCommandWriter.cpp
     DEPS motors_roboteq_canopen)

--- a/test/test_Channel.cpp
+++ b/test/test_Channel.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include <motors_roboteq_canopen/Driver.hpp>
+#include <motors_roboteq_canopen/Channel.hpp>
+
+using namespace motors_roboteq_canopen;
+using canopen_master::PDOMapping;
+
+struct ChannelTest : public ::testing::Test {
+    canopen_master::StateMachine canopen;
+    Driver driver;
+    Channel& channel;
+
+    ChannelTest()
+        : canopen(0x1)
+        , driver(canopen, 2) // use not-the-first channel to make sure we apply the subid properly
+        , channel(driver.getChannel(1)) {}
+};
+
+TEST_F(ChannelTest, it_does_not_query_anything_in_TPDO_while_ignored) {
+    channel.setControlMode(CONTROL_IGNORED);
+    auto queries = channel.getJointStateTPDOMapping();
+    ASSERT_TRUE(queries.empty());
+}
+
+TEST_F(ChannelTest, it_queries_amp_pwm_and_status_in_TPDO_while_open_loop) {
+    channel.setControlMode(CONTROL_OPEN_LOOP);
+    auto queries = channel.getJointStateTPDOMapping();
+    ASSERT_EQ(1, queries.size());
+    auto& mapping = queries[0];
+    ASSERT_EQ(mapping.mappings[0],
+              (PDOMapping::MappedObject{ 0x2100, 2, 2 }));
+    ASSERT_EQ(mapping.mappings[1],
+              (PDOMapping::MappedObject{ 0x2102, 2, 2 }));
+    ASSERT_EQ(mapping.mappings[2],
+              (PDOMapping::MappedObject{ 0x2122, 2, 2 }));
+}
+
+TEST_F(ChannelTest, it_queries_amp_pwm_feedback_and_status_in_TPDO_while_closed_loop) {
+    channel.setControlMode(CONTROL_TORQUE);
+    auto queries = channel.getJointStateTPDOMapping();
+    ASSERT_EQ(1, queries.size());
+    auto& mapping = queries[0];
+    ASSERT_EQ(mapping.mappings[0],
+              (PDOMapping::MappedObject{ 0x2100, 2, 2 }));
+    ASSERT_EQ(mapping.mappings[1],
+              (PDOMapping::MappedObject{ 0x2102, 2, 2 }));
+    ASSERT_EQ(mapping.mappings[2],
+              (PDOMapping::MappedObject{ 0x2110, 2, 2 }));
+    ASSERT_EQ(mapping.mappings[3],
+              (PDOMapping::MappedObject{ 0x2122, 2, 2 }));
+}

--- a/test/test_DS402Driver.cpp
+++ b/test/test_DS402Driver.cpp
@@ -48,8 +48,11 @@ TEST_F(DriverTest, it_queries_controller_status) {
           0x2112, 0,
           0x210F, 1,
           0x210F, 2,
+          0x2122, 1,
           0x210F, 3,
-          0x210F, 4 }
+          0x2122, 2,
+          0x210F, 4,
+          0x2122, 3 }
     );
 }
 
@@ -61,8 +64,11 @@ TEST_F(DriverTest, it_returns_controller_status) {
     can_open.set<uint16_t>(0x2112, 0, 0xabcd);
     can_open.set<int8_t>(0x210F, 1, 50);
     can_open.set<int8_t>(0x210F, 2, 100);
+    can_open.set<uint16_t>(0x2122, 1, 16);
     can_open.set<int8_t>(0x210F, 3, 120);
+    can_open.set<uint16_t>(0x2122, 2, 8);
     can_open.set<int8_t>(0x210F, 4, -20);
+    can_open.set<uint16_t>(0x2122, 3, 24);
     ControllerStatus status = driver.getControllerStatus();
     ASSERT_FLOAT_EQ(2, status.voltage_internal);
     ASSERT_FLOAT_EQ(2.5, status.voltage_battery);
@@ -71,8 +77,11 @@ TEST_F(DriverTest, it_returns_controller_status) {
     ASSERT_EQ(0xabcd, status.fault_flags);
     ASSERT_FLOAT_EQ(50, status.temperature_mcu.getCelsius());
     ASSERT_FLOAT_EQ(100, status.temperature_sensors.at(0).getCelsius());
+    ASSERT_EQ(16, status.channel_status_flags[0]);
     ASSERT_FLOAT_EQ(120, status.temperature_sensors.at(1).getCelsius());
+    ASSERT_EQ(8, status.channel_status_flags[1]);
     ASSERT_FLOAT_EQ(-20, status.temperature_sensors.at(2).getCelsius());
+    ASSERT_EQ(24, status.channel_status_flags[2]);
 }
 
 TEST_F(DriverTest, it_sets_up_joint_state_TPDOs) {


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-canopen_master/pull/7

There was 2 bytes left in the joint state PDO, use it to get
the channel status flags, and add it to the ControllerStatus
structure